### PR TITLE
Fix version constraint for protobuf to be compatible with tensorflow-intel 2.18.0 (AIV-801)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.24.3,<2.0.0
 onnx >= 1.14.0
-protobuf == 3.20.2
+protobuf>=3.20.2
 torch>=1.12.0,<2.3.0
 onnxsim
 tqdm


### PR DESCRIPTION
## Description

This project contains a strict dependency for `protobuf==3.20.2`, but this breaks compatibility with `tensorflow-intel==2.18.0`. This PR relaxes that constraint to `protobuf>=3.20.2`.

<img src="https://github.com/user-attachments/assets/f17f6ee6-ae74-445f-a602-5f822444cfa4" width=1000px>

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
