### PR TITLE
fix(espdl): serialize scalar tensors with dims=[1] to avoid esp-dl load crash

### DIFF
--- a/esp_ppq/parser/espdl/helper.py
+++ b/esp_ppq/parser/espdl/helper.py
@@ -410,6 +410,14 @@ def make_tensor(
         raise ValueError(
             f"Number of values does not match tensor's size. Expected {expected_size}, but it is {len(vals)}. "
         )
+    # Coerce rank-0 (scalar) tensors to shape [1]. esp-dl's fbs loader
+    # (FbsModel::get_operation_parameter) reads a tensor's data using its dims and crashes with a
+    # null-pointer LoadProhibited (EXCVADDR=0x0) during Model::load() when dims is empty. Scalar
+    # params occur for e.g. the scale/zero_point of QuantizeLinear/RequantizeLinear ops inserted at
+    # branch-boundary scale changes. This mirrors the rank-0 -> [1] coercion already applied to test
+    # input/output values above.
+    if len(dims) == 0:
+        dims = [1]
     dims = builder.CreateNumpyVector(np.array(dims, dtype=np.int64))
     exponents = builder.CreateNumpyVector(np.array(exponents, dtype=np.int64))
     if doc_string:

--- a/tests/test_scalar_tensor_dims.py
+++ b/tests/test_scalar_tensor_dims.py
@@ -1,0 +1,51 @@
+"""Regression test for scalar (rank-0) tensor serialization in the ESP-DL exporter.
+
+`helper.make_tensor` must serialize a scalar (empty `dims`) tensor with shape `[1]`, not `[]`.
+esp-dl's fbs loader (`FbsModel::get_operation_parameter`) reads a parameter's data using its dims
+and dereferences a null pointer (LoadProhibited, EXCVADDR=0x0) during `Model::load()` on-device when
+a parameter has empty dims. Such scalar params occur for e.g. the scale / zero_point of
+QuantizeLinear / RequantizeLinear ops that esp-ppq inserts at branch-boundary scale changes, so any
+branchy / multi-output quantized model can trigger the crash.
+
+This is a pure-CPU unit test (no CUDA needed).
+"""
+import os
+import sys
+
+# helper.py imports the generated flatbuffers as top-level `FlatBuffers.Dl.*`, so the espdl parser
+# directory must be importable.
+_ESPDL_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "esp_ppq", "parser", "espdl"))
+if _ESPDL_DIR not in sys.path:
+    sys.path.insert(0, _ESPDL_DIR)
+
+from esp_ppq.parser.espdl import helper  # noqa: E402
+import FlatBuffers.Dl.Tensor as Tensor  # noqa: E402
+import FlatBuffers.Dl.TensorDataType as TensorDataType  # noqa: E402
+
+
+def _make_and_read(dims, vals):
+    helper.reset_global_fbs_builder()
+    builder = helper.get_global_fbs_builder()
+    offset = helper.make_tensor("t", TensorDataType.TensorDataType().FLOAT, dims, vals)
+    builder.Finish(offset)
+    t = Tensor.Tensor.GetRootAs(builder.Output(), 0)
+    read_dims = [t.Dims(i) for i in range(t.DimsLength())]
+    helper.reset_global_fbs_builder()
+    return read_dims
+
+
+def test_scalar_tensor_dims_coerced_to_one():
+    # rank-0 scalar -> must become [1] (else esp-dl crashes on load)
+    assert _make_and_read([], [0.5]) == [1]
+
+
+def test_nonscalar_tensor_dims_unchanged():
+    # regular tensors must be left exactly as-is
+    assert _make_and_read([3], [1.0, 2.0, 3.0]) == [3]
+    assert _make_and_read([2, 2], [1.0, 2.0, 3.0, 4.0]) == [2, 2]
+
+
+if __name__ == "__main__":
+    test_scalar_tensor_dims_coerced_to_one()
+    test_nonscalar_tensor_dims_unchanged()
+    print("PASS")


### PR DESCRIPTION
## Summary

`esp_ppq.parser.espdl.helper.make_tensor` serializes **rank-0 (scalar) tensors with empty `dims=[]`**. When such a tensor is a model **parameter**, esp-dl's flatbuffer loader (`FbsModel::get_operation_parameter`) computes the data size from `dims` and dereferences a null pointer, crashing **on-device** during `Model::load()`:

```
Guru Meditation Error: Core 0 panic'ed (LoadProhibited). EXCVADDR: 0x00000000
... fbs::FbsModel::get_operation_parameter(...) at fbs_loader/src/fbs_model.cpp:658
... dl::Model::load(fbs::FbsModel*) at dl/model/src/dl_model_base.cpp:170
```

## Root cause

Scalar parameters are produced for, e.g., the `scale` / `zero_point` of the `QuantizeLinear` / `RequantizeLinear` ops that esp-ppq inserts at **branch-boundary scale changes** (skip connections, multi-input adds, multi-output graphs). These serialize with `dims=[]`, which esp-dl's loader cannot read.

This is an internal inconsistency: `make_tensor` **already** coerces rank-0 → `[1]` for **test input/output values** (the `if len(input_shape) == 0: input_shape = [1]` block earlier in `helper.py`), but **not** for regular parameter tensors.

## Fix

Apply the same rank-0 → `[1]` coercion to all tensors in `make_tensor` (one element either way; data is unchanged). After this, no parameter is serialized with empty dims and the model loads.

## Verification

- **Host:** parsing the exported `.espdl` shows the previously-`dims=[]` scalar params (`QuantizeLinear`/`RequantizeLinear` scale/zero_point) now serialize with `dims=[1]`; no rank-0 parameter tensors remain.
- **On-device:** a branchy multi-output int8 model (a CNN feature extractor with skip connections, pyramid fusion, and 3 outputs) that previously crashed at `Model::load()` on an **ESP32-S3** now loads and runs successfully after this fix. Before the fix, every export of that model crashed identically regardless of model content; this was the only change required.
- Added a CPU-only unit test (`tests/test_scalar_tensor_dims.py`) asserting scalar tensors serialize as `[1]` and non-scalar tensors are unchanged.

## Test

```
$ python -m pytest tests/test_scalar_tensor_dims.py
```
