### PR TITLE
fix(morph): group-aware weight transform in ConvTranspose decomposition (grouped/depthwise)

### DIFF
--- a/esp_ppq/IR/morph.py
+++ b/esp_ppq/IR/morph.py
@@ -1438,9 +1438,24 @@ class GraphDecomposer(GraphCommandProcessor):
             # Flip all spatial dimensions (dims 2 and above)
             spatial_dims_indices = list(range(2, weight_dim))
             weight_flipped = torch.flip(weight_value, dims=spatial_dims_indices)
-            # Transpose input/output channels: ConvTranspose weight shape is [C_in, C_out, *spatial]
-            # Conv weight shape is [C_out, C_in, *spatial]
-            weight_for_conv = weight_flipped.transpose(0, 1).contiguous()
+            # Swap input/output channels, group-aware.
+            # ConvTranspose weight shape is [C_in, C_out / group, *spatial];
+            # the equivalent Conv weight shape is [C_out, C_in / group, *spatial].
+            # A plain transpose(0, 1) is only correct for group == 1; for grouped/depthwise
+            # ConvTranspose it yields the wrong shape ([C_out / group, C_in, *spatial]) and the
+            # following Conv fails (e.g. "Given groups=G, expected weight to be at least G at
+            # dimension 0, but got weight of size [1, C_in, ...]"). Do the swap within each group.
+            c_in = weight_flipped.shape[0]
+            c_out_per_group = weight_flipped.shape[1]
+            spatial = list(weight_flipped.shape[2:])
+            c_in_per_group = c_in // group
+            c_out = c_out_per_group * group
+            weight_for_conv = (
+                weight_flipped.reshape(group, c_in_per_group, c_out_per_group, *spatial)
+                .transpose(1, 2)
+                .reshape(c_out, c_in_per_group, *spatial)
+                .contiguous()
+            )
 
             # Update original weight variable for Conv
             weight_var.value = weight_for_conv

--- a/tests/test_convtranspose_decomposition.py
+++ b/tests/test_convtranspose_decomposition.py
@@ -291,6 +291,48 @@ def test_conv1d_convtranspose():
     return all_success
 
 
+def test_grouped_convtranspose():
+    """Test grouped / depthwise ConvTranspose decomposition.
+
+    Regression test: ConvTranspose weight has shape [C_in, C_out / group, *spatial], so swapping
+    input/output channels with a plain transpose(0, 1) only works for group == 1. For grouped /
+    depthwise ConvTranspose the decomposed Conv used to get the wrong weight shape and fail.
+    """
+    print("\nTesting grouped / depthwise ConvTranspose decomposition...")
+
+    # (in_channels, out_channels, groups): a non-trivial grouped case + a pure depthwise case.
+    configs = [
+        (4, 8, 2),    # grouped (C_out / group = 4)
+        (8, 8, 8),    # depthwise (C_out / group = 1) -- the case that used to crash
+        (6, 6, 3),    # grouped depth-like
+    ]
+    all_success = True
+    for in_ch, out_ch, groups in configs:
+        model = nn.ConvTranspose2d(in_ch, out_ch, kernel_size=3, stride=2, padding=1,
+                                   output_padding=1, groups=groups, bias=True).eval()
+        sample_input = torch.randn(1, in_ch, 16, 16)
+        with torch.no_grad():
+            reference_output = model(sample_input)
+
+        onnx_path = Path(f'test_grouped_convtranspose_{in_ch}_{out_ch}_g{groups}.onnx')
+        torch.onnx.export(model, sample_input, onnx_path, input_names=['input'],
+                          output_names=['output'], opset_version=11)
+        graph = load_onnx_graph(str(onnx_path))
+        GraphDecomposer(graph).decompose_convtranspose()
+
+        executor = TorchExecutor(graph, device='cpu')
+        decomposed_output = executor.forward(inputs=sample_input, output_names=['output'])[0]
+
+        max_diff = torch.max(torch.abs(reference_output - decomposed_output)).item()
+        ok = max_diff < 1e-5
+        print(f"  in={in_ch} out={out_ch} groups={groups}: max diff {max_diff:.2e} "
+              f"{'✓' if ok else '✗'}")
+        all_success = all_success and ok
+        onnx_path.unlink(missing_ok=True)
+
+    return all_success
+
+
 if __name__ == '__main__':
     try:
         print("=" * 60)
@@ -300,8 +342,9 @@ if __name__ == '__main__':
         success1 = test_numerical_accuracy()
         success2 = test_various_configurations()
         success3 = test_conv1d_convtranspose()
+        success4 = test_grouped_convtranspose()
 
-        if success1 and success2 and success3:
+        if success1 and success2 and success3 and success4:
             print("\n" + "=" * 60)
             print("All numerical tests passed! ✓")
             print("=" * 60)


### PR DESCRIPTION
## Summary

`GraphDecomposer.decompose_convtranspose` swaps the input/output channels of the ConvTranspose weight with a plain `transpose(0, 1)`. A ConvTranspose weight has shape `[C_in, C_out / group, *spatial]`, so this is only correct for `group == 1`. For a **grouped / depthwise** ConvTranspose it produces the wrong Conv weight shape (`[C_out / group, C_in, *spatial]` instead of `[C_out, C_in / group, *spatial]`), and the decomposed `Conv` then fails, e.g.:

```
RuntimeError: Given groups=64, expected weight to be at least 64 at dimension 0,
but got weight of size [1, 64, 4, 4] instead
```

So any model that uses a grouped / depthwise transposed convolution currently **cannot be quantized for ESP-DL**.

## Why it matters

Depthwise / grouped transposed convolutions are the standard, efficient way to do learnable upsampling in lightweight networks — common in segmentation decoders (U-Net / FCN style), super-resolution, and autoencoder / decoder architectures, which are exactly the kinds of efficient models targeted at ESP-DL.

Concretely: in a feature extractor we deploy to ESP32-S3, working around this by using a full (`groups=1`, block-diagonal) ConvTranspose made those two upsampling layers cost **886 ms + 267 ms** per inference. With the depthwise ConvTranspose decomposing correctly after this fix, the same layers drop to **1.2 ms + 0.78 ms** (and the model shrinks by ~320 KB) — i.e. this also unblocks a large, real performance win, not just a crash.

## Fix

Do the input/output channel swap **within each group**:

```python
weight_flipped.reshape(group, c_in_per_group, c_out_per_group, *spatial)
              .transpose(1, 2)
              .reshape(c_out, c_in_per_group, *spatial)
```

This reduces to the existing `transpose(0, 1)` for `group == 1`, so behavior for the common case is unchanged.

## Testing

Extended `tests/test_convtranspose_decomposition.py` with grouped / depthwise cases (`groups=2`, depthwise `groups=8`, `groups=3`). They decompose and match the reference ConvTranspose to ~1e-7 with the fix, and fail (the crash above) without it. The existing `group=1` tests are unaffected.

```
$ python tests/test_convtranspose_decomposition.py
...
  in=4 out=8 groups=2: max diff 1.19e-07 ✓
  in=8 out=8 groups=8: max diff 2.53e-07 ✓
  in=6 out=6 groups=3: max diff 1.19e-07 ✓
All numerical tests passed! ✓
```
