### PR TITLE
Fix keepdims handling in layout_patterns.py

### DIFF
--- a/esp_ppq/parser/espdl/layout_patterns.py
+++ b/esp_ppq/parser/espdl/layout_patterns.py
@@ -238,9 +238,9 @@ class AxisTransformPattern(OperationExporter):
 
         out_var_perm = var_perm[:]
         if op.type in REDUCE_OP_SET:
-            keepdims = op.attributes["keepdims"]
+            keepdims = bool(op.attributes.get("keepdims", 1))
             # The perm needs to be deleted.
-            if keepdims == 0:
+            if not keepdims:
                 if len(op.inputs) > 1 and len(op.inputs[1].value) > 0:
                     reduce_axes_list = sorted(op.inputs[1].value.tolist(), reverse=True)
                     # After the transformations above, the axes now match the current input.


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Add default value with the same pattern as esp_ppq/executor/op/torch/default.py. I didn't check every operator, but I believe keepdims should always default to 1. Here's an example in the ONNX docs: https://onnx.ai/onnx/operators/onnx__ReduceMean.html.
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
